### PR TITLE
Support starting and registering pluins sideloaded.

### DIFF
--- a/src/freenet/node/NodeStarter.java
+++ b/src/freenet/node/NodeStarter.java
@@ -585,9 +585,11 @@ public class NodeStarter implements WrapperListener {
 	}
 
 	// experimental osgi support
-	public static void start_osgi(String[] args) {
+	public static Node start_osgi(String[] args) {
 		nodestarter_osgi = new NodeStarter();
 		nodestarter_osgi.start(args);
+
+		return nodestarter_osgi.node;
 	}
 
 	// experimental osgi support

--- a/src/freenet/pluginmanager/PluginManager.java
+++ b/src/freenet/pluginmanager/PluginManager.java
@@ -365,6 +365,33 @@ public class PluginManager {
 		return realStartPlugin(new PluginDownLoaderFreenet(client, node, false), filename, store, false);
 	}
 
+	/**
+	 * Registers an externally loaded plugin.
+	 *
+	 * @param plug Plugin instance.
+	 * @return
+	 */
+	public PluginInfoWrapper startPlugin(FredPlugin plug) {
+	    final String filename = plug.getClass().getName();
+		Logger.normal(this, "Loading plugin: " + filename);
+		PluginInfoWrapper pi = null;
+		try {
+			pi = new PluginInfoWrapper(node, plug, filename, true);
+			PluginHandler.startPlugin(PluginManager.this, pi);
+			loadedPlugins.addLoadedPlugin(pi);
+			loadedPlugins.removeFailedPlugin(filename);
+			Logger.normal(this, "Plugin loaded: " + filename);
+		} catch (Throwable e) {
+			Logger.error(this, "Could not load plugin " + filename + " : " + e, e);
+			System.err.println("Could not load plugin " + filename + " : " + e);
+			e.printStackTrace();
+			System.err.println("Plugin "+filename+" is broken, but we want to retry after next startup");
+			Logger.error(this, "Plugin "+filename+" is broken, but we want to retry after next startup");
+		}
+
+		return pi;
+	}
+
 	private PluginInfoWrapper realStartPlugin(final PluginDownLoader<?> pdl, final String filename, final boolean store, boolean alwaysDownload) {
 	    if (!enabled) throw new IllegalStateException("Plugins disabled");
 		if(filename.trim().length() == 0)


### PR DESCRIPTION
Add startPlugin method to the plugin manager to support starting and registering sideloaded plugins. RFC: https://cryptpad.piratenpartei.de/code/#/2/code/edit/R4L8NhS135nRe2G38vpKW5PO/

Short summary: Freenet plugins on Android will be bundled into the app thus no jar will be loaded by the plugin manager. The plugins will be available at compile time and instantiated at Fred startup, then passed to the plugin manager to start and register.